### PR TITLE
Minor changes related to passwords

### DIFF
--- a/bga_discord.py
+++ b/bga_discord.py
@@ -280,7 +280,7 @@ async def setup_bga_account(message, bga_username, bga_password):
     await account.close_connection()
     if logged_in:
         save_data(discord_id, player_id, bga_username, bga_password)
-        await message.channel.send(f"Account {bga_username} setup successfully.")
+        await message.channel.send(f"Account {bga_username} set up successfully. I will remember your password and, when asked, use it to make tables on your behalf.")
     else:
         await message.author.send("Bad username or password. Try putting quotes around both.")
 

--- a/bga_discord.py
+++ b/bga_discord.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import logging
 import logging.handlers
+from bga_logging import BGALoggingFormatter
 import os
 import re
 import shlex
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger('discord').setLevel(logging.WARN)
 # Add the log message handler to the logger
 handler = logging.handlers.RotatingFileHandler(LOG_FILENAME, maxBytes=10000000, backupCount=0)
-formatter = logging.Formatter('%(asctime)s | %(name)s | %(levelname)s | %(message)s')
+formatter = BGALoggingFormatter('%(asctime)s | %(name)s | %(levelname)s | %(message)s')
 handler.setFormatter(formatter)
 logger.addHandler(handler)
 logger.setLevel(logging.DEBUG)

--- a/bga_help_msg.md
+++ b/bga_help_msg.md
@@ -11,6 +11,10 @@ These commands will work in any channel @BGA is on and also as direct messages t
     This bot will delete this message after you send it.
     If either username or password has spaces, use quotes.
 
+    This bot will remember your BGA password forever. If you’d like to
+    deauthorise the bot from acting on your behalf, change your password at
+    <https://boardgamearena.com/preferences?section=account>.
+
 ## **link @discord_tag bga_username**
     NOTE: If you run setup, linking accounts is done automatically.
 

--- a/bga_logging.py
+++ b/bga_logging.py
@@ -1,0 +1,11 @@
+import logging
+import re
+
+
+class BGALoggingFormatter(logging.Formatter):
+    """Remove passwords from log messages."""
+
+    def format(self, record):
+        record.msg = re.sub(r'\b(setup\s+\S+\s+)(\S+)', r'\1*HIDDEN*',
+                            record.msg)
+        return logging.Formatter.format(self, record)


### PR DESCRIPTION
- Remind the user that by running the `setup` comamnd, they gave away their password.
- Document what they should do if they decide that that wasn’t a great idea.
- Try not to write the password into a debug log.