### PR TITLE
Tell text editors not to insert a newline at the end of each file.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+insert_final_newline = false


### PR DESCRIPTION
Fixes #8.