### PR TITLE
Stricter filesystem permissions for keys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ TOKEN = 'yOUR tOkeN hEre'
 Generate an encryption key with:
 
 ```bash
-python -c 'from cryptography.fernet import Fernet; print("FERNET_KEY = %s" % Fernet.generate_key())' >> keys.py
+( umask 077 && python -c 'from cryptography.fernet import Fernet; print("FERNET_KEY = %s" % Fernet.generate_key())' >> src/keys.py )
 ```
 
 Run:

--- a/src/creds_iface.py
+++ b/src/creds_iface.py
@@ -3,6 +3,7 @@
 from cryptography.fernet import Fernet
 import json
 import os
+import stat
 
 from keys import FERNET_KEY
 
@@ -25,7 +26,7 @@ def save_data(discord_id, bga_userid, bga_username, bga_password):
     user_json[str(discord_id)] = {"bga_userid": bga_userid, "username": bga_username, "password": bga_password}
     updated_text = json.dumps(user_json)
     reencrypted_text = cipher_suite.encrypt(bytes(updated_text, encoding="utf-8"))
-    with open("src/bga_keys", "wb") as f:
+    with os.fdopen(os.open("src/bga_keys", os.O_WRONLY | os.O_CREAT, stat.S_IRUSR | stat.S_IWUSR), "wb") as f:
         f.write(reencrypted_text)
 
 


### PR DESCRIPTION
By creating files containing keys in such a way that only their owner can read them, we make it slightly harder for the contents of those files to accidentally leak.

Tangentially relates to issue #4.