### PR TITLE
Prevent `ImportError: cannot import name 'CONTRIBUTORS' from 'keys'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Generate an encryption key with:
 ( umask 077 && python -c 'from cryptography.fernet import Fernet; print("FERNET_KEY = %s" % Fernet.generate_key())' >> src/keys.py )
 ```
 
+Store your Discord username (replacing `$USER` in the following command):
+
+```bash
+python -c 'from pprint import pformat; import sys; print("CONTRIBUTORS = " + pformat(sys.argv[1:]))' "$USER" >> src/keys.py
+```
+
 Run:
 
 ```bash

--- a/src/cmd_sub_setup.py
+++ b/src/cmd_sub_setup.py
@@ -6,7 +6,10 @@ from creds_iface import get_all_logins
 from discord_utils import send_options_embed
 from tfm_create_game import AVAILABLE_TFM_OPTIONS
 from creds_iface import save_data
-from keys import CONTRIBUTORS
+try:
+    from keys import CONTRIBUTORS
+except ImportError:
+    CONTRIBUTORS = []
 from utils import normalize_name
 
 

--- a/src/cmd_sub_setup.py
+++ b/src/cmd_sub_setup.py
@@ -6,6 +6,7 @@ from creds_iface import get_all_logins
 from discord_utils import send_options_embed
 from tfm_create_game import AVAILABLE_TFM_OPTIONS
 from creds_iface import save_data
+
 try:
     from keys import CONTRIBUTORS
 except ImportError:


### PR DESCRIPTION
Belt and braces fix for issue #21:

- Document the CONTRIBUTORS configuration in the README
- Make missing CONTRIBUTORS non-fatal