### PR TITLE
Document the requirement for Server Members Intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Run the following on any VPS
 pip install -r requirements.txt
 ```
 
-Follow the steps required to [set up a Discord bot account](https://discordpy.readthedocs.io/en/latest/discord.html) with the following permissions:
+Follow the steps required to [set up a Discord bot account](https://discordpy.readthedocs.io/en/latest/discord.html) with the following privileged gateway intents:
+
+- Server Members Intent
+
+Add the following permissions:
 
 - Send Messages
 - Send TTS Messages


### PR DESCRIPTION
Fixes #23.

This comes with the following warning in the Discord admin UI:

> NOTE: Once your bot reaches 100 or more servers, this will require Verification and whitelisting. Read more here

Verification sounds like hassle, so it may be better in the long term to consider removing this intent.  I think itʼs only used in `get_discord_id()`, and, from the [discordpy documentation](https://discordpy.readthedocs.io/en/latest/api.html#discord.MemberCacheFlags), my untested impression is that the only drawback may be that `guild.members` will gradually fill up with members whoʼve actually left the guild.