### PR TITLE
Fix `coroutine 'Messageable.send' was never awaited`

### DIFF
--- a/src/menu_root.py
+++ b/src/menu_root.py
@@ -71,7 +71,7 @@ async def trigger_interactive_response(message, contexts, curr_ctx, args):
             if message.content.isdigit() and "1" <= message.content <= "3":
                 contexts[author]["subcommand"] = ["setup", "play", "status"][int(message.content) - 1]
             else:
-                message.channel.send("Enter a number between 1 and 3 (see embed above)")
+                await message.channel.send("Enter a number between 1 and 3 (see embed above)")
                 return
         if contexts[author]["subcommand"] == "timeout":
             await send_options_embed(message, "BGA bot option", ["setup", "play", "status"])


### PR DESCRIPTION
If you direct message the bot `hello` twice consecutively, the following error is triggered:

```
/home/mavit/src/bga_discord/src/menu_root.py:74: RuntimeWarning: coroutine 'Messageable.send' was never awaited
  message.channel.send("Enter a number between 1 and 3 (see embed above)")
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

This commit fixes that, addressing #25.