### PR TITLE
Relax game name matching when creating a table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,7 @@ kill:
 	@kill `cat pid` 2>/dev/null || true
 run: kill
 	@python3 -u src/main.py 2>&1 >> errs & echo $$! > pid
+
+test: export PYTHONPATH=src
+test:
+	@python3 -m unittest discover -s tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 aiohttp
 cryptography
 discord.py==1.5.0
+num2words
+unidecode

--- a/src/bga_game_list.json
+++ b/src/bga_game_list.json
@@ -270,9 +270,6 @@
   "Yin Yang": 1226,
   "Yokai": 1181,
   "Yokohama": 1161,
-  "welcometo": "1300",
   "Tichu": 1237,
-  "sevenwondersduelagora": "1279",
-  "carcassonnehuntersandgatherers": "1276",
-  "lettertycoon": "1273"
+  "sevenwondersduelagora": "1279"
 }

--- a/src/bga_game_list.py
+++ b/src/bga_game_list.py
@@ -129,8 +129,6 @@ async def get_games_by_name_part(name_part):
     games = []
 
     for normalized_name, simplified_name in simplified_games.items():
-        logger.debug(f"normalized_name={normalized_name} simplified_name={simplified_name}")
-        logger.debug(f"name_part={name_part}")
         if simplified_name == simplified_name_part:  # if there's an exact match, take it!
             return [normalized_name]
         elif simplified_name.startswith(simplified_name_part):

--- a/src/bga_game_list.py
+++ b/src/bga_game_list.py
@@ -8,7 +8,7 @@ import time
 
 import aiohttp
 
-from utils import normalize_name
+from utils import normalize_name, simplify_name
 
 logging.getLogger("aiohttp").setLevel(logging.WARN)
 
@@ -88,11 +88,51 @@ def update_games_cache(games):
         f.write(json.dumps(games, indent=2) + "\n")
 
 
-async def is_game_valid(game):
-    # Check if any words are games
+async def is_game_valid(name):
+    return normalize_name(name) in await get_simplified_game_list()
+
+
+async def get_simplified_game_list():
     games, errs = await get_game_list()
     if errs:
         games, errs = get_game_list_from_cache()
-    normalized_games = [normalize_name(g) for g in games]
-    normalized_game = normalize_name(game)
-    return normalized_game in normalized_games
+
+    simplified_games = {}
+    for full_name in games:
+        simplified_games[normalize_name(full_name)] = simplify_name(full_name)
+    return simplified_games
+
+
+async def get_id_by_game(normalized_name):
+    games, errs = await get_game_list()
+    if errs:
+        games, errs = get_game_list_from_cache()
+
+    for title, id in games.items():
+        if normalize_name(title) == normalized_name:
+            return id
+
+
+async def get_title_by_game(normalized_name):
+    games, errs = await get_game_list()
+    if errs:
+        games, errs = get_game_list_from_cache()
+
+    for title in games:
+        if normalize_name(title) == normalized_name:
+            return title
+
+
+async def get_games_by_name_part(name_part):
+    simplified_name_part = simplify_name(name_part)
+    simplified_games = await get_simplified_game_list()
+    games = []
+
+    for normalized_name, simplified_name in simplified_games.items():
+        logger.debug(f"normalized_name={normalized_name} simplified_name={simplified_name}")
+        logger.debug(f"name_part={name_part}")
+        if simplified_name == simplified_name_part:  # if there's an exact match, take it!
+            return [normalized_name]
+        elif simplified_name.startswith(simplified_name_part):
+            games.append(normalized_name)
+    return games

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,4 +1,6 @@
 """Utils for various parts of this program"""
+from num2words import num2words
+from unidecode import unidecode
 from urllib.parse import urlparse
 import re
 
@@ -49,7 +51,27 @@ async def send_message_partials(destination, remainder):
 
 
 def normalize_name(game_name):
+    """Generate a string that can be used to uniquely identify a game."""
     return re.sub("[^a-z0-7]+", "", game_name.lower())
+
+
+def simplify_name(game_name):
+    """Generate a string that can be used for comparing/matching the name of a game in a more reliable way than using user input directly."""
+    game_name = game_name.lower()
+    game_name = unidecode(game_name)
+    game_name = re.sub(r"\s+", " ", game_name)
+    game_name = re.sub(r"^the ", "", game_name)
+    game_name = re.sub(r"[!(].*", "", game_name)
+    if not re.search(r"\b(?:builders|through the ages)", game_name):
+        game_name = re.sub(r":.*", "", game_name)
+    game_name = re.sub(r"^voyages of ", "", game_name)
+    game_name = re.sub(r"of miller.?s +hollow$", "", game_name)
+    game_name = re.sub(r" & " , " and ", game_name)
+    game_name = re.sub(r"\bii\b" , "two", game_name)
+    game_name = re.sub(r"\d+", lambda m: num2words(m.group()), game_name)
+    game_name = re.sub(r"[^a-z]+", "", game_name)
+
+    return game_name
 
 
 def force_double_quotes(string):

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,7 +62,10 @@ def simplify_name(game_name):
     game_name = re.sub(r"\s+", " ", game_name)
     game_name = re.sub(r"^the ", "", game_name)
     game_name = re.sub(r"[!(].*", "", game_name)
-    if not re.search(r"\b(?:builders|through the ages)", game_name):
+    if not re.search(
+            r"\b(?:builders|carcassonne|through the ages)\b",
+            game_name
+    ):
         game_name = re.sub(r":.*", "", game_name)
     game_name = re.sub(r"^voyages of ", "", game_name)
     game_name = re.sub(r"of miller.?s +hollow$", "", game_name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,58 @@
+from bga_game_list import get_game_list_from_cache
+from utils import simplify_name
+import unittest
+
+
+class TestUtils(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.games, errs = await get_game_list_from_cache()
+
+    def test_simplify_name(self):
+        # Exercise all of the existing simplifications rules:
+        self.assertEqual(simplify_name("Gaïa"), "gaia")
+        self.assertEqual(simplify_name("6  Nimmt!"), "sixnimmt")
+        self.assertEqual(
+            simplify_name("The Jelly Monster Lab"),
+            "jellymonsterlab"
+        )
+        self.assertEqual(
+            simplify_name("99 (trick-taking card game)"),
+            "ninetynine"
+        )
+        self.assertEqual(
+            simplify_name("Unconditional Surrender! World War 2 in Europe "),
+            "unconditionalsurrender"
+        )
+        self.assertEqual(
+            simplify_name("The Builders: Middle Ages"),
+            "buildersmiddleages"
+        )
+        self.assertEqual(simplify_name("Through the Ages"), "throughtheages")
+        self.assertEqual(
+            simplify_name("Through the Ages: A new Story of Civilization"),
+            "throughtheagesanewstoryofcivilization"
+        )
+        self.assertEqual(
+            simplify_name("Marco Polo II: In the Service of the Khan"),
+            "marcopolotwo"
+        )
+        self.assertEqual(
+            simplify_name("The Voyages of Marco Polo"),
+            "marcopolo"
+        )
+        self.assertEqual(
+            simplify_name("The Werewolves of Miller's Hollow"),
+            "werewolves"
+        )
+        self.assertEqual(simplify_name("Gear & Piston"), "gearandpiston")
+
+        # Check for any collisions between simplified names:
+        simplified_names = set()
+        for full_name in self.games:
+            simplified_name = simplify_name(full_name)
+            self.assertNotIn(simplified_name, simplified_names)
+            simplified_names.add(simplified_name)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Users are unlikely to have memorised the exact wording and orthography of the titles of games, so lets work harder to understand what they mean.

Some examples:
- `6 nimmt!` ↦ `sixnimmt`
- `Gaïa` ↦ `gaia`
- `Gear & Piston` ↦ `gearandpiston`
- `The Voyages of Marco Polo` ↦ `marcopolo`
- `Marco Polo II: In the Service of the Khan` ↦ `marcopolotwo`